### PR TITLE
[fix] glarePrerender ¯\_(ツ)_/¯

### DIFF
--- a/src/tilt.jquery.js
+++ b/src/tilt.jquery.js
@@ -136,15 +136,19 @@
          * Prepare elements
          */
         const prepareGlare = function () {
+            const glarePrerender = this.settings.glarePrerender;
 
             // If option pre-render is enabled we assume all html/css is present for an optimal glare effect.
-            if (!this.settings.glarePrerender)
+            if (!glarePrerender)
                 // Create glare element
                 $(this).append('<div class="js-tilt-glare"><div class="js-tilt-glare-inner"></div></div>');
 
             // Store glare selector if glare is enabled
             this.glareElementWrapper = $(this).find(".js-tilt-glare");
             this.glareElement = $(this).find(".js-tilt-glare-inner");
+            
+            // Remember? We assume all css is already set, so just return
+            if (glarePrerender) return;
 
             // Abstracted re-usable glare styles
             const stretch = {

--- a/src/tilt.jquery.js
+++ b/src/tilt.jquery.js
@@ -138,10 +138,9 @@
         const prepareGlare = function () {
 
             // If option pre-render is enabled we assume all html/css is present for an optimal glare effect.
-            if(this.settings.glarePrerender) return;
-
-            // Create glare element
-            $(this).append(`<div class="js-tilt-glare"><div class="js-tilt-glare-inner"></div></div>`);
+            if (!this.settings.glarePrerender)
+                // Create glare element
+                $(this).append('<div class="js-tilt-glare"><div class="js-tilt-glare-inner"></div></div>');
 
             // Store glare selector if glare is enabled
             this.glareElementWrapper = $(this).find(".js-tilt-glare");


### PR DESCRIPTION
If you return right away then `this.glareElementWrapper` is not defined ¯\_(ツ)_/¯
And it breaks hard ¯\_(ツ)_/¯